### PR TITLE
:sparkles: Add AllowedIps

### DIFF
--- a/Mundipagg/Models/Response/GetAccountResponse.cs
+++ b/Mundipagg/Models/Response/GetAccountResponse.cs
@@ -27,6 +27,8 @@ namespace Mundipagg.Models.Response
 
         public string[] Domains { get; set; }
 
+        public string[] AllowedIps { get; set; }    
+
         public GetMundipaggSettingsResponse MundipaggSettings { get; set; }
 
         public GetPagarmeSettingsResponse PagarmeSettings { get; set; }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Inserts the property AllowedIpds into GetAccountResponse.

### Why?

It exists in the creation and update, but it does not come in the get response