### PR TITLE
[Feature] Adds pix settings when creating account

### DIFF
--- a/Mundipagg/Models/Request/CreateAccountRequest.cs
+++ b/Mundipagg/Models/Request/CreateAccountRequest.cs
@@ -68,6 +68,8 @@ namespace Mundipagg.Models.Request
         public CreateWebhookSettingRequest[] WebhokoSettings { get; set; }
 
         public CreateAttemptSettingsRequest AttemptSettings { get; set; }
+
+        public CreatePixSettingsRequest PixSettingsRequest { get; set; }
     }
 
     public class CreateBoletoSettingsRequest
@@ -244,5 +246,12 @@ namespace Mundipagg.Models.Request
         public bool MultiBuyersEnabled { get; set; }
 
         public bool OpenOrdersEnabled { get; set; }
+    }
+
+    public class CreatePixSettingsRequest
+    {
+        public bool Enabled { get; set; }
+
+        public string Gateway { get; set; }
     }
 }


### PR DESCRIPTION
![Git Merge](https://camo.githubusercontent.com/0c23369892fc55b17d9ced5306b44e02f5dc3d3ca961f1c611db95e13eacdfb9/68747470733a2f2f737465616d75736572696d616765732d612e616b616d616968642e6e65742f7567632f3836353131373430393432363131313833392f393930433042324130454542333141414337383234424331343236363342453432393041433036362f3f696d773d3530303026696d683d3530303026696d613d66697426696d706f6c6963793d4c6574746572626f7826696d636f6c6f723d253233303030303030266c6574746572626f783d66616c7365)

### Status

READY

### Whats?

Adds the pix settings when building the create account request.

### Why?

Because of the new feature that let us configure the pix when creating the account.