### PR TITLE
[Bugfix] Fix object used to create split rules on cancel charge

### DIFF
--- a/Mundipagg/Models/Request/CreateCancelChargeRequest.cs
+++ b/Mundipagg/Models/Request/CreateCancelChargeRequest.cs
@@ -9,6 +9,6 @@ namespace Mundipagg.Models.Request
     {
         public int? Amount { get; set; }
 
-        public List<CreateCancelChargeSplitRulesRequest> SplitRules { get; set; }
+        public List<CreateSplitRequest> SplitRules { get; set; }
     }
 }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cdNSp4L5vCU7aQrYnV/giphy.gif)

### Status

READY

### Whats?

Fix wrong split object used on cancel charge

### Why?

To be able to cancel charge with split rules

### How?

Change the wrong split object

![image](https://user-images.githubusercontent.com/4581068/127571027-42407cc0-1b18-4a85-990f-37f735d23c93.png)

