### PR TITLE
[Feature] Adds culture treatment to DateTime objects

### DIFF
--- a/Mundipagg.Tests/Util/DictionaryUtilTest.cs
+++ b/Mundipagg.Tests/Util/DictionaryUtilTest.cs
@@ -40,6 +40,24 @@ namespace Mundipagg.Tests.Util
             // Assert
             Assert.Equal(ex.ParamName, "source");
         }
+
+        [Theory]
+        [InlineData("11/07/2021 21:00:00", "07/11/2021 21:00:00")]
+        [InlineData("2020-11-19T00:00:00", "11/19/2020 00:00:00")]
+        [InlineData("01/01/2021 21:00:00", "01/01/2021 21:00:00")]
+        public void Should_Convert_DateTime(string originalDate, string expectedDate)
+        {
+            DictionaryUtilTestClass obj = new DictionaryUtilTestClass
+            {
+                CreatedAt = DateTime.Parse(originalDate)
+            };
+
+            // Act
+            var result = DictionaryUtil.ToDictionary(obj);
+
+            // Assert
+            Assert.Equal(expectedDate, result["created_at"]);
+        }
     }
 
     public class DictionaryUtilTestClass
@@ -49,6 +67,8 @@ namespace Mundipagg.Tests.Util
         public string Name { get; set; }
 
         public int Age { get; set; }
+
+        public DateTime? CreatedAt { get; set; }
 
         public CustomerTypeEnum CustomerType { get; set; }
     }

--- a/Mundipagg.Tests/Util/DictionaryUtilTest.cs
+++ b/Mundipagg.Tests/Util/DictionaryUtilTest.cs
@@ -1,6 +1,7 @@
 ﻿using Mundipagg.Models.Enums;
 using Mundipagg.Utils;
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace Mundipagg.Tests.Util
@@ -49,7 +50,7 @@ namespace Mundipagg.Tests.Util
         {
             DictionaryUtilTestClass obj = new DictionaryUtilTestClass
             {
-                CreatedAt = DateTime.Parse(originalDate)
+                CreatedAt = DateTime.Parse(originalDate, new CultureInfo("pt-BR"))
             };
 
             // Act

--- a/Mundipagg/Utils/DictionaryUtil.cs
+++ b/Mundipagg/Utils/DictionaryUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace Mundipagg.Utils
 {
@@ -40,6 +41,13 @@ namespace Mundipagg.Utils
                 {
                     value = ((Enum)value).GetEnumMember();
                 }
+
+                if (value is DateTime)
+                {
+                    var date = (DateTime)value;
+                    value = date.ToString(CultureInfo.InvariantCulture);
+                }
+
                 dictionary.Add(property.Name.ToSnakeCase(), value.ToString());
             }
         }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Added a culture treatment for DateTime objects when they are converted to string.

### Why?

Because the dates, when sent with a culture context such as pt-BR, given that the search interprets dd/mm/yyyy, were swapped. For example, sending the date 17/07/2021 would be sent as-is to Makr1, and would receive a Bad Request response, because it was interpreting it as having a Month value of 17, which is impossible.

### How?

With the culture invariant treatment, now all dates will be sent in mm/dd/yyy, which is what is needed for the searches.

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [x] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
