### PR TITLE
[BugFix] Add nullable query parameters for Status and PaymentMethod on ListChargeRequest

### DIFF
--- a/Mundipagg/Models/Request/ListChargesRequest.cs
+++ b/Mundipagg/Models/Request/ListChargesRequest.cs
@@ -15,9 +15,9 @@ namespace Mundipagg.Models.Request
 
         public string OrderId { get; set; }
 
-        public PaymentMethodTypeEnum PaymentMethod { get; set; }
+        public PaymentMethodTypeEnum? PaymentMethod { get; set; } = PaymentMethodTypeEnum.CreditCard;
 
-        public ChargeStatusEnum Status { get; set; }
+        public ChargeStatusEnum? Status { get; set; } = ChargeStatusEnum.Pending;
 
         public string InitiatorTransactionKey { get; set; }
     }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

On charge request that has not filters on status or payment_method, the SDK does not allow to pass null to this properties, this cause a unexpected behavior when searching for charges that are on an unknown payment_method or status

### Why?

My application do a search with ITK parameter as unique id, and it doesn't need to know what payment method or what status the charge is.

### How?

Letting the PaymentMethodType and Status attribute opitional do the client, but maintaining the retro compatibility with the systens who use the default 0 enum value a.k.a Pending and Credit_Card

### Evidences

Searching for Cash charge at any status

![image](https://user-images.githubusercontent.com/17494785/139142934-90d7ddfd-1d6b-49a5-a3a7-548c28b05022.png)

Searching with standard filters

![image](https://user-images.githubusercontent.com/17494785/139143898-f950bb22-25ec-40f6-832c-b1e6b3689e31.png)

Searching a pending charge with credit card

![image](https://user-images.githubusercontent.com/17494785/139144415-66e1c3c0-dd81-43df-ab0a-b00f268872a5.png)
