### PR TITLE
[Feature] Add open order resource

### DIFF
--- a/Mundipagg/Models/Request/ListChargesRequest.cs
+++ b/Mundipagg/Models/Request/ListChargesRequest.cs
@@ -15,9 +15,9 @@ namespace Mundipagg.Models.Request
 
         public string OrderId { get; set; }
 
-        public PaymentMethodTypeEnum PaymentMethod { get; set; }
+        public PaymentMethodTypeEnum? PaymentMethod { get; set; } = PaymentMethodTypeEnum.CreditCard;
 
-        public ChargeStatusEnum Status { get; set; }
+        public ChargeStatusEnum? Status { get; set; } = ChargeStatusEnum.Pending;
 
         public string InitiatorTransactionKey { get; set; }
     }

--- a/Mundipagg/Resources/Interface/IOrderResource.cs
+++ b/Mundipagg/Resources/Interface/IOrderResource.cs
@@ -100,6 +100,19 @@ namespace Mundipagg.Resources.Interface
         /// <return>Returns Models.BaseResponse<GetOrderResponse> response from the API call</return>
         Task<BaseResponse<GetOrderResponse, MundipaggErrorsResponse>> CloseOrderAsync(string id, UpdateOrderStatusRequest request);
 
+        /// <summary>
+        /// Opens an order
+        /// </summary>
+        /// <param name="id">Required parameter: Order Id</param>
+        /// <return>Returns Models.BaseResponse<GetOrderResponse> response from the API call</return>
+        BaseResponse<GetOrderResponse, MundipaggErrorsResponse> OpenOrder(string id);
+
+        /// <summary>
+        /// Opens an order
+        /// </summary>
+        /// <param name="id">Required parameter: Order Id</param>
+        /// <return>Returns Models.BaseResponse<GetOrderResponse> response from the API call</return>
+        Task<BaseResponse<GetOrderResponse, MundipaggErrorsResponse>> OpenOrderAsync(string id);
         #endregion
 
         #region Order Item

--- a/Mundipagg/Resources/OrderResource.cs
+++ b/Mundipagg/Resources/OrderResource.cs
@@ -120,6 +120,22 @@ namespace Mundipagg.Resources
             return await this.SendRequestAsync<GetOrderResponse>(method, endpoint, request);
         }
 
+        public BaseResponse<GetOrderResponse, MundipaggErrorsResponse> OpenOrder(string id)
+        {
+            var method = new HttpMethod("PATCH");
+            var endpoint = $"/orders/{id}/open";
+
+            return this.SendRequest<GetOrderResponse>(method, endpoint);
+        }
+
+        public async Task<BaseResponse<GetOrderResponse, MundipaggErrorsResponse>> OpenOrderAsync(string id)
+        {
+            var method = new HttpMethod("PATCH");
+            var endpoint = $"/orders/{id}/open";
+
+            return await this.SendRequestAsync<GetOrderResponse>(method, endpoint);
+        }
+
         #endregion
 
         #region Order Item 


### PR DESCRIPTION
### Status

READY

### Whats?

The client already can do a CloseOrder, but if he needs to include another charge, he must create another order to do that. With this PR the client now can reopen an order to put more charges on that.

### Why?

The idea of this feature is to give the hability of Order.Closed attribute management to the client,  with this, any client will can open an order, include a charge and than close the order again

### How?

Adding a new resource on IOrderResource interface like the code bellow:
```csharp
        BaseResponse<GetOrderResponse, MundipaggErrorsResponse> OpenOrder(string id);
        Task<BaseResponse<GetOrderResponse, MundipaggErrorsResponse>> OpenOrderAsync(string id);        
```

### Evidences

![ezgif-2-2883aca269f1](https://user-images.githubusercontent.com/17494785/141129247-73fb44e8-312d-48ed-9b34-0725ea656f0f.gif)

### Merge
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)
