### PR TITLE
[Feature] Fix cryptogram type and name

### DIFF
--- a/Mundipagg.ConsoleTest/Program.cs
+++ b/Mundipagg.ConsoleTest/Program.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Mundipagg.Models.Commons;
 using Mundipagg.Models.Request;
 using Mundipagg.Models.Webhooks;
 using Newtonsoft.Json;
@@ -273,15 +271,18 @@ namespace Mundipagg.ConsoleTest
                     {
                         GatewayAffiliationId = "merchantkey",
                         Amount = 10000,
-                        CreditCard = new CreateCreditCardPaymentRequest()
+                        CreditCard = new CreateCreditCardPaymentRequest
                         {
                             Authentication = null,
                             Capture = false,
-                            NetworkToken = new CreateNetworkTokenRequest()
+                            NetworkToken = new CreateNetworkTokenRequest
                             {
-                                Criptogram = "ANfQt43bddROAAEnSAMhAAADFA====",
+                                Cryptograms =  new List<string>
+                                {
+                                    "ANfQt43bddROAAEnSAMhAAADFA===="
+                                },
                                 Number = "5256621004565548",
-                                BillingAddress = new NetworkTokenAddress()
+                                BillingAddress = new NetworkTokenAddress
                                 {
                                     City = "Malibu",
                                     Country = "US",

--- a/Mundipagg/Models/Request/CreateNetworkTokenRequest.cs
+++ b/Mundipagg/Models/Request/CreateNetworkTokenRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -11,7 +12,7 @@ namespace Mundipagg.Models.Request
         public int ExpMonth { get; set; }
         public int ExpYear { get; set; }
         public string TokenRequestorId { get; set; }
-        public string Criptogram { get; set; }
+        public List<string> Cryptograms { get; set; }
         public virtual NetworkTokenAddress BillingAddress { get; set; }
     }
 


### PR DESCRIPTION
![Git Merge](https://camo.githubusercontent.com/ff471ec5d199b8f956af8286e076708bbcbc29d56f94708cc9d2284b44227f40/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f577133324d665953393571356434584b37762f67697068792e676966)

### Status

READY

### Whats?
Fix cryptogram type and name

### Why?
To mark1 accept network token request correctly.

### How?
By changing the type and name of cryptogram property.

### Attachments (if appropriate)
Stg log evidence:
![DeepinScreenshot_select-area_20220224170118](https://user-images.githubusercontent.com/5938864/155598591-58f12d06-057c-4d29-9ef6-1910229beab6.png)

RequestKey for consult: RequestKey = 'beeee34e-5a5d-4d49-9046-f462a11edc51'

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
