### PR TITLE
[Feature] EndToEndId and Payer into CreatePixPaymentRequest / Id and SplitOptions into GetSplitResponse

### DIFF
--- a/Mundipagg/Models/Request/CreatePixPaymentRequest.cs
+++ b/Mundipagg/Models/Request/CreatePixPaymentRequest.cs
@@ -15,6 +15,10 @@ namespace Mundipagg.Models.Request
 
         public string QRCode { get; set; }
 
+        public string EndToEndId { get; set; }
+
+        public PixPayerRequest Payer { get; set; }
+
         public List<PixAdditionalInformation> AdditionalInformation { get; set; }
 
         public CreatePOIRequest Poi { get; set; }

--- a/Mundipagg/Models/Request/PixBankAccountRequest.cs
+++ b/Mundipagg/Models/Request/PixBankAccountRequest.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Mundipagg.Models.Request
+{
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class PixBankAccountRequest
+    {
+        public string BankName { get; set; }
+
+        public string Ispb { get; set; }
+
+        public string BranchCode { get; set; }
+
+        public string AccountNumber { get; set; }
+    }
+}

--- a/Mundipagg/Models/Request/PixPayerRequest.cs
+++ b/Mundipagg/Models/Request/PixPayerRequest.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Mundipagg.Models.Request
+{
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class PixPayerRequest
+    {
+        public string Name { get; set; }
+
+        public string Document { get; set; }
+
+        public string DocumentType { get; set; }
+
+        public PixBankAccountRequest BankAccount { get; set; }
+    }
+}

--- a/Mundipagg/Models/Response/GetSplitOptionsRequest.cs
+++ b/Mundipagg/Models/Response/GetSplitOptionsRequest.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Mundipagg.Models.Response
+{
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class GetSplitOptionsRequest
+    {
+        public bool Liable { get; set; }
+
+        public bool ChargeProcessingFee { get; set; }
+
+        public bool ChargeRemainderFee { get; set; }
+    }
+}

--- a/Mundipagg/Models/Response/GetSplitResponse.cs
+++ b/Mundipagg/Models/Response/GetSplitResponse.cs
@@ -6,6 +6,8 @@ namespace Mundipagg.Models.Response
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class GetSplitResponse
     {
+        public string Id { get; set; }
+
         public int Amount { get; set; }
 
         public string GatewayId { get; set; }
@@ -13,5 +15,7 @@ namespace Mundipagg.Models.Response
         public GetRecipientResponse Recipient { get; set; }
 
         public string Type { get; set; }
+
+        public GetSplitOptionsRequest SplitOptions { get; set; }
     }
 }


### PR DESCRIPTION
![Git Merge](http://pa1.narvii.com/6471/69326493f70a8371c8cba9e63bdc21cee3c6db54_00.gif)

### Status

READY

### Whats?

Added new properties: 
 - EndToEndId and Payer properties into CreatePixPaymentRequest; 
 - Id and SplitOptions (GetSplitOptionsRequest Class too) into GetSplitResponse.

### Why?

Following the Mark1 Payment model for Physical World PIX, we see that it has Payer and EndToEndId data, it is necessary to insert this data in the SDK's CreatePixPaymentRequest Class.

The same happens for mark1's Split model, we see that it has SplitOptions data, unlike the SDK. We need to insert this data in the GetSplitResponse Class.

### How?

With the properties now added into the SDK, Payer/EnToEndId can be used to store Pix data on requests, and Split new will be returned with it's options on Get requests.

Payer and EnToEndId being sent by SDK to mark1:
![image](https://user-images.githubusercontent.com/17272586/159075851-8b4a18c3-ddb8-4625-b69a-9143aabf8efc.png)


### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
