### PR TITLE
[Bugfix] Renaming of SplitOptions property based on mark1 contract (Options)

### DIFF
--- a/Mundipagg/Models/Response/GetSplitResponse.cs
+++ b/Mundipagg/Models/Response/GetSplitResponse.cs
@@ -16,6 +16,6 @@ namespace Mundipagg.Models.Response
 
         public string Type { get; set; }
 
-        public GetSplitOptionsRequest SplitOptions { get; set; }
+        public GetSplitOptionsRequest Options { get; set; }
     }
 }


### PR DESCRIPTION
![Git Merge](http://pa1.narvii.com/6471/69326493f70a8371c8cba9e63bdc21cee3c6db54_00.gif)

### Status

READY

### Whats?

Renamed property **SplitOptions** on **GetTransactionResponse** to **Options** Class.

### Why?

Following the Mark1 GetTransactionResponse model, we see that it has **SplitOptions** is sent as **Options** on it's contract. So it is necessary to rename this property on the SDK.

### How?

With the property now renamed in the SDK, **Options** can be used to store SplitOptions data on responses that are returned from Mark1 on Authorize, Capture, Cancellation or TransactionStatusReport operations.

Examples:

SplitOptions received as **options** on SDK from mark1 (Cancellation):
![image](https://user-images.githubusercontent.com/17272586/162991331-7f1ec866-2202-4703-98d3-c7899073a178.png)

SplitOptions received as **options** SDK from mark1 (Capture):
![image](https://user-images.githubusercontent.com/17272586/162991569-a6532431-6e36-44be-9686-a798aa59287f.png)

SplitOptions received as **options** SDK from mark1 (TransactionStatusReport):
![image](https://user-images.githubusercontent.com/17272586/163871909-dc149667-f434-4c6f-982a-abc6a14e0cfb.png)

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
