### PR TITLE
[Feature] Add Cancellation Url To Checkout

### DIFF
--- a/Mundipagg.ConsoleTest/Program.cs
+++ b/Mundipagg.ConsoleTest/Program.cs
@@ -59,24 +59,14 @@ namespace Mundipagg.ConsoleTest
                 {
                     new CreatePaymentRequest
                     {
+                        PaymentMethod = "checkout",
                         Amount = 5000,
-                        PaymentMethod = "private_label",
-                        PrivateLabel = new CreatePrivateLabelPaymentRequest
+                        Checkout = new CreateCheckoutPaymentRequest
                         {
-                            Capture = true,
-                            Installments = 1,
-                            StatementDescriptor = "No Quarter",
-                            Card = new CreateCardRequest
-                            {
-                                Number = "4000000000000010",
-                                Cvv = "123",
-                                ExpMonth = 12,
-                                ExpYear = 2030,
-                                Brand = "elo",
-                                Label = "Pernambucanas",
-                                HolderName = "Teste Da Silva",
-                                HolderDocument = "80487236033"
-                            }
+                            AcceptedPaymentMethods = new List<string>{"credit_card"},
+                            SuccessUrl = "https://google.com",
+                            CancellationUrl = "https://pagar.me",
+                            ExpiresIn = 90000
                         }
                     }
                 }

--- a/Mundipagg/Models/Request/CreateCheckoutPaymentRequest.cs
+++ b/Mundipagg/Models/Request/CreateCheckoutPaymentRequest.cs
@@ -39,6 +39,8 @@ namespace Mundipagg.Models.Request
 
         public string SuccessUrl { get; set; }
 
+        public string CancellationUrl { get; set; }
+
         public CreateCheckoutPixPaymentRequest Pix { get; set; }
     }
 }

--- a/Mundipagg/Models/Response/GetCheckoutPaymentResponse.cs
+++ b/Mundipagg/Models/Response/GetCheckoutPaymentResponse.cs
@@ -56,6 +56,8 @@ namespace Mundipagg.Models.Response
 
         public string SuccessUrl { get; set; }
 
+        public string CancellationUrl { get; set; }
+
         public DateTime UpdatedAt { get; set; }
 
         public GetCheckoutPixPaymentResponse Pix { get; set; }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/G7iGNzr3VBING/giphy.gif)

### Status

READY

### Whats?

Added the cancellation url field for CreateCheckoutPayment request and response.

### Why?

It was necessary in order to send a cancellation url to Mark1. This url will be used to add a cancel payment button on the Checkout.

### How?

By adding the field on the request and response dtos, it was possible to solve the problem.

### Attachments

The CancellationUrl being sent on the request:
![Evidência sdk](https://user-images.githubusercontent.com/49206390/182178724-ba59d76f-d0a9-4617-acc7-772ff94a15a3.PNG)


### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
