### PR TITLE
[improvement] Inclusão do campo ServiceRefererName

### DIFF
--- a/Mundipagg/Configuration.cs
+++ b/Mundipagg/Configuration.cs
@@ -35,6 +35,7 @@ namespace Mundipagg
         /// <param name="timeout"></param>
         /// <param name="mpToken"></param>
         /// <param name="accountManagementKey"></param>
+        /// <param name="serviceRefererName"></param>
         public Configuration(
             string secretKey = null, 
             string requestKey = null, 
@@ -42,7 +43,8 @@ namespace Mundipagg
             int? timeout = null,
             string mpToken = null,
             string accountManagementKey = null,
-            bool enableLog = false)
+            bool enableLog = false,
+            string serviceRefererName = null)
         {
             this.SecretKey = secretKey;
             this.ApiUrl = apiUrl ?? API_URL;
@@ -51,6 +53,7 @@ namespace Mundipagg
             this.MpToken = mpToken;
             this.AccountManagementKey = accountManagementKey;
             this.EnableLog = enableLog;
+            this.ServiceRefererName = serviceRefererName;
         }
 
         /// <summary>
@@ -97,7 +100,12 @@ namespace Mundipagg
         /// Timeout in milliseconds
         /// </summary>
         public int Timeout { get; set; }
-    
+
+        /// <summary>
+        /// Service Referer Name
+        /// </summary>
+        public string ServiceRefererName { get; set; }
+
         public Configuration Clone()
         {
             return (Configuration) this.MemberwiseClone();

--- a/Mundipagg/IMundipaggApiClient.cs
+++ b/Mundipagg/IMundipaggApiClient.cs
@@ -74,6 +74,7 @@ namespace Mundipagg
         /// <param name="merchantId"></param>
         /// <param name="accountId"></param>
         /// <param name="enableLog"></param>
+        /// <param name="serviceRefererName"></param>
         void UpdateConfiguration(string secretKey = null,
             string requestKey = null,
             string apiUrl = null,
@@ -82,6 +83,7 @@ namespace Mundipagg
             string accountManagementKey = null,
             string merchantId = null,
             string accountId = null,
-            bool enableLog = false);
+            bool enableLog = false,
+            string serviceRefererName = null);
     }
 }

--- a/Mundipagg/MundipaggApiClient.cs
+++ b/Mundipagg/MundipaggApiClient.cs
@@ -44,7 +44,8 @@ namespace Mundipagg
             this.Initialize(new Configuration(secretKey, requestKey, apiUrl, timeout, mpToken, accountManagementKey, enableLog, serviceRefererName)
             {
                 MerchantId = merchantId,
-                AccountId = accountId
+                AccountId = accountId,
+                ServiceRefererName = serviceRefererName
             });
         }
 

--- a/Mundipagg/MundipaggApiClient.cs
+++ b/Mundipagg/MundipaggApiClient.cs
@@ -135,7 +135,7 @@ namespace Mundipagg
             this._configuration.Timeout = timeout ?? this._configuration.Timeout;
             this._configuration.ApiUrl = apiUrl ?? this._configuration.ApiUrl;
             this._configuration.EnableLog = enableLog;
-            this._configuration.ServiceRefererName = serviceRefererName;
+            this._configuration.ServiceRefererName = serviceRefererName ?? this._configuration.ServiceRefererName;
             this.Configuration = _configuration;
         }
 

--- a/Mundipagg/MundipaggApiClient.cs
+++ b/Mundipagg/MundipaggApiClient.cs
@@ -28,6 +28,7 @@ namespace Mundipagg
         /// <param name="merchantId"></param>
         /// <param name="accountId"></param>
         /// <param name="enableLog"></param>
+        /// <param name="serviceRefererName"></param>
         public MundipaggApiClient(
             string secretKey = null,
             string requestKey = null,
@@ -37,9 +38,10 @@ namespace Mundipagg
             string accountManagementKey = null,
             string merchantId = null,
             string accountId = null,
-            bool enableLog = false)
+            bool enableLog = false, 
+            string serviceRefererName = null)
         {
-            this.Initialize(new Configuration(secretKey, requestKey, apiUrl, timeout, mpToken, accountManagementKey, enableLog)
+            this.Initialize(new Configuration(secretKey, requestKey, apiUrl, timeout, mpToken, accountManagementKey, enableLog, serviceRefererName)
             {
                 MerchantId = merchantId,
                 AccountId = accountId
@@ -111,6 +113,7 @@ namespace Mundipagg
         /// <param name="merchantId"></param>
         /// <param name="accountId"></param>
         /// <param name="enableLog"></param>
+        /// <param name="serviceRefererName"></param>
         public void UpdateConfiguration(
             string secretKey = null,
             string requestKey = null,
@@ -120,7 +123,8 @@ namespace Mundipagg
             string accountManagementKey = null,
             string merchantId = null,
             string accountId = null,
-            bool enableLog = false)
+            bool enableLog = false, 
+            string serviceRefererName = null)
         {
             this._configuration.SecretKey = secretKey ?? this._configuration.SecretKey;
             this._configuration.AccountId = accountId ?? this._configuration.AccountId;
@@ -131,6 +135,7 @@ namespace Mundipagg
             this._configuration.Timeout = timeout ?? this._configuration.Timeout;
             this._configuration.ApiUrl = apiUrl ?? this._configuration.ApiUrl;
             this._configuration.EnableLog = enableLog;
+            this._configuration.ServiceRefererName = serviceRefererName;
             this.Configuration = _configuration;
         }
 

--- a/Mundipagg/Resources/BaseResource.cs
+++ b/Mundipagg/Resources/BaseResource.cs
@@ -45,7 +45,8 @@ namespace Mundipagg.Resources
                 var additionalLog = new Dictionary<string, string>()
                 {
                     { "AccountId", this._configuration.AccountId },
-                    { "MerchantId", this._configuration.MerchantId }
+                    { "MerchantId", this._configuration.MerchantId },
+                    { "ServiceRefererName", this._configuration.ServiceRefererName }
                 };
 
                 this.EasyRestClient = new EasyRestClient(value.ApiUrl,


### PR DESCRIPTION
### [PANOT-86](https://mundipagg.atlassian.net/browse/PANOT-86) 

![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Inclusão do campo ServiceRefererName.

### Why?

Para que POSConnect possa mostrar ao Mark1 a sua origem.

### How?

Adicionando o campo ServiceRefererName no Configuration e no MundipaggApiClient.

![image](https://user-images.githubusercontent.com/101657650/181807359-85f9b5c4-afeb-4855-bebd-d64fa02b243d.png)

Teste realizado utilizando a comunicação entre POSConnect e Mark1 logando o ServiceRefererName no header do request.
Desta maneira o Mark1 pode identificar a origem da transação como POSConnect o que possibilita que o Mark1 possa tomar a decisão da criação do evento de webhook passando pelo fluxo 2.0. E também possibilita uma melhor identificação no log.

Requisição de autorização, criando uma order no POSConnect:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/101657650/182854060-3a8f3634-600f-47e2-a59f-112b05c8dd52.png">

Requisição no Mark1 com a criação da order logando o ServiceRefererName com origem "POSConnect":
<img width="749" alt="image" src="https://user-images.githubusercontent.com/101657650/182853294-4e5837eb-e898-416b-8208-8a94db6ed74a.png">
