### PR TITLE
[Feat] Include Payment Provider on CreatePaymentRequest

### DIFF
--- a/Mundipagg/Models/Enums/PaymentProviderEnum.cs
+++ b/Mundipagg/Models/Enums/PaymentProviderEnum.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Mundipagg.Models.Enums
+{
+    public enum PaymentProviderEnum
+    {
+        [EnumMember(Value = "mundipagg")]
+        Mundipagg,
+
+        [EnumMember(Value = "pagarme")]
+        Pagarme,
+    }
+}

--- a/Mundipagg/Models/Enums/ProviderNameEnum.cs
+++ b/Mundipagg/Models/Enums/ProviderNameEnum.cs
@@ -2,7 +2,7 @@
 
 namespace Mundipagg.Models.Enums
 {
-    public enum PaymentProviderEnum
+    public enum ProviderNameEnum
     {
         [EnumMember(Value = "mundipagg")]
         Mundipagg,

--- a/Mundipagg/Models/Enums/ProviderNameEnum.cs
+++ b/Mundipagg/Models/Enums/ProviderNameEnum.cs
@@ -4,10 +4,10 @@ namespace Mundipagg.Models.Enums
 {
     public enum ProviderNameEnum
     {
-        [EnumMember(Value = "mundipagg")]
-        Mundipagg,
+        [EnumMember(Value = "gateway")]
+        Gateway,
 
-        [EnumMember(Value = "pagarme")]
-        Pagarme,
+        [EnumMember(Value = "psp")]
+        Psp,
     }
 }

--- a/Mundipagg/Models/Request/CreatePaymentRequest.cs
+++ b/Mundipagg/Models/Request/CreatePaymentRequest.cs
@@ -1,3 +1,4 @@
+using Mundipagg.Models.Enums;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using PagarMe.Models.Request;
@@ -11,6 +12,8 @@ namespace Mundipagg.Models.Request
         public int? Amount { get; set; }
 
         public string Code { get; set; }
+
+        public PaymentProviderEnum? Provider { get; set; }
 
         public CreateBankTransferPaymentRequest BankTransfer { get; set; }
 

--- a/Mundipagg/Models/Request/CreatePaymentRequest.cs
+++ b/Mundipagg/Models/Request/CreatePaymentRequest.cs
@@ -13,7 +13,7 @@ namespace Mundipagg.Models.Request
 
         public string Code { get; set; }
 
-        public PaymentProviderEnum? Provider { get; set; }
+        public ProviderNameEnum? ProviderName { get; set; }
 
         public CreateBankTransferPaymentRequest BankTransfer { get; set; }
 


### PR DESCRIPTION
# [feature] Include Payment Provider on CreatePaymentRequest

![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Create new field responsible for choose wich payment gateway provider will process the transaction: Mundipagg or Pagar.me.

### Why?

To let the POS clients the option to chose the provider.

### How?

Changing the contract adding the provider field 

### Evidence

Mundipagg
![image](https://user-images.githubusercontent.com/17494785/186779068-7aee59d2-3d27-4441-b45e-aeac50ecd43f.png)


Pagarme
![image](https://user-images.githubusercontent.com/17494785/186779149-dc1cb926-cedf-49e8-8138-ba20591690a1.png)


None of them
![image](https://user-images.githubusercontent.com/17494785/186779240-1a878510-f022-46a7-86db-02b458029e06.png)



### Definition of Done:
- [ ] Increases API documentation
- [x] Implements integration tests
- [x] Implements unit tests
- [x] Is there appropriate logging included?
- [x] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.