### PR TITLE
[Feature] Include PaidAt property into CreatePixPaymentRequest

### DIFF
--- a/Mundipagg/Models/Request/CreatePixPaymentRequest.cs
+++ b/Mundipagg/Models/Request/CreatePixPaymentRequest.cs
@@ -9,6 +9,8 @@ namespace Mundipagg.Models.Request
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     public class CreatePixPaymentRequest
     {
+        public DateTime? PaidAt { get; set; }
+
         public DateTime? ExpiresAt { get; set; }
 
         public int? ExpiresIn { get; set; }


### PR DESCRIPTION
![Git Merge](http://pa1.narvii.com/6471/69326493f70a8371c8cba9e63bdc21cee3c6db54_00.gif)

### Status

READY

### Whats?

Added new property **PaidAt** on **CreatePixPaymentRequest** Class.

### Why?

The prop will be added on Mark1's CreatePixPaymentRequest model. So it is necessary to insert **PaidAt** in the SDK's CreatePixPaymentRequest Class too.

### How?

With the property now added into the SDK, **PaidAt** can be used to store the payment date on Mark1's charge entity when created to Third Party PIXs.

Examples:

Payment date being received on POSConnect:

![image](https://user-images.githubusercontent.com/17272586/191782823-a8b7cbb3-3648-46e2-a12b-6b7d594daf0b.png)

PaidAt being sent to Mark1 via SDK:

![image](https://user-images.githubusercontent.com/17272586/191782985-e8d1e9ae-85bb-40f8-b85a-51eed54effee.png)

Mark1 storing the payment date in its Charge entity:

![image](https://user-images.githubusercontent.com/17272586/191783339-1893b894-2cfb-4b62-a774-7b0bbdde5104.png)

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
