### PR TITLE
[Feature] Include PartnerName and PartnerVersionId to CreatePOIRequest

### DIFF
--- a/Mundipagg/Models/Request/CreateDevicePOIRequest.cs
+++ b/Mundipagg/Models/Request/CreateDevicePOIRequest.cs
@@ -13,7 +13,5 @@
         public string VersionNumber { get; set; }
 
         public string CommunicationType { get; set; }
-
-        public string PartnerName { get; set; }
     }
 }

--- a/Mundipagg/Models/Request/CreatePOIRequest.cs
+++ b/Mundipagg/Models/Request/CreatePOIRequest.cs
@@ -4,6 +4,10 @@ namespace Mundipagg.Models.Request
 {
     public class CreatePOIRequest
     {
+        public string PartnerName { get; set; }
+
+        public string PartnerVersionId { get; set; }
+
         public string InitiatorTransactionKey { get; set; }
 
         public string CardSequenceNumber { get; set; }


### PR DESCRIPTION
![Git Merge](http://pa1.narvii.com/6471/69326493f70a8371c8cba9e63bdc21cee3c6db54_00.gif)

### Status

READY

### Whats?

Added new properties `PartnerName` and `PartnerVersionId` on `CreatePOIRequest` Class.

### Why?

These props will be added on Mark1's `CreatePOIRequest` model. So it is necessary to insert `PartnerName` and `PartnerVersionId` in the SDK's `CreatePOIRequest` Class too.

### How?

With the properties now added into the SDK, `PartnerName` and `PartnerVersionId` can be used to store the partner name and version id on Mark1's POI's entity.

### Tests

![image](https://user-images.githubusercontent.com/17272586/209389229-de522a3a-9e24-4f2c-8faa-79dbd3c6c338.png)

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [ ] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
