### PR TITLE
[Feature] Adds naming strategy type snake case to GetTransactionResponse

### DIFF
--- a/Mundipagg/Models/Response/GetTransactionResponse.cs
+++ b/Mundipagg/Models/Response/GetTransactionResponse.cs
@@ -1,10 +1,12 @@
 using Mundipagg.Models.Converters;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace Mundipagg.Models.Response
 {
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     [JsonConverter(typeof(GetTransactionResponseCreationConverter))]
     public class GetTransactionResponse
     {


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/jyDc9mR1kIlDW/giphy.gif)

### Status

READY

### Whats?

Adição do NamingStrategyType snake case na classe GetTransactionResponse

### Why?
Projetos que não utilizam o scaffolding, acabam tendo problemas de mapear o objeto de classes da SDK que não possuem esse parametro. Pois o scaffolding faz essa conversão por padrão.

### How?

Adicionei o inline parameter NamingStrategyType para realizar a conversão automaticamente. Adicionei a dll atualizada localmente no projeto e o objeto passou a ser mapeado corretamente.

### Evidências

<details>
<summary>Antes</summary>

![Screenshot_7](https://user-images.githubusercontent.com/5938864/209666100-81cf9c12-f37f-4162-90a2-898b89062a78.png)

**Projeto cliente da sdk**

![Screenshot_6](https://user-images.githubusercontent.com/5938864/209666060-a029bc9f-79d2-4370-9b9e-095e25ccd9de.png)

</details>


<details>
<summary>Depois</summary>

![Screenshot_5](https://user-images.githubusercontent.com/5938864/209666115-51216ea7-58ad-4db1-abf5-c7f95d9b3d5a.png)

**Projeto cliente da sdk (dll adicionada localmente com a correção)**

![Screenshot_4](https://user-images.githubusercontent.com/5938864/209666132-c2b56f0f-2cfb-4940-b124-5ff7006a03d9.png)

</details>
